### PR TITLE
fix(helmrelease): set replicaCount to integer for komoplane-10 and annotate kagentFix

### DIFF
--- a/apps/overlay/control-cluster/hr-failed.yaml
+++ b/apps/overlay/control-cluster/hr-failed.yaml
@@ -14,6 +14,8 @@ kind: HelmRelease
 metadata:
   name: komoplane-10
   namespace: test
+  annotations:
+    kagentFix: "2025-09-16T21:34:00Z"
 spec:
   interval: 5m
   chart:
@@ -23,5 +25,5 @@ spec:
         kind: HelmRepository
         name: komodorio
   values:
-    replicaCount: "1o" # Intentional error: should be an integer, not a string
+    replicaCount: 1
 ---


### PR DESCRIPTION
RCA:
The HelmRelease test/komoplane-10 failed during install because values.replicaCount was set to the string "1o". Kubernetes Deployment.spec.replicas expects an integer (int32). Helm attempted to create a Deployment with replicas set to the string which caused a JSON unmarshal error: "json: cannot unmarshal string into Go struct field DeploymentSpec.spec.replicas of type int32".

Remediation:
- Change values.replicaCount from "1o" to integer 1 in apps/overlay/control-cluster/hr-failed.yaml.
- Add annotation kagentFix=<timestamp> to the HelmRelease metadata to mark the remediation.

Actions taken:
- Created branch fix/komoplane-10-replica-fix-20250916t213400z from local.
- Updated apps/overlay/control-cluster/hr-failed.yaml with the fix.

Please let Flux reconcile the repository; the HelmRelease should reattempt install and succeed.
