### PR TITLE
fix(helmrelease): correct komoplane replicaCount and annotate kagentFix (kagent ai agent)

### DIFF
--- a/apps/overlay/control-cluster/hr-failed.yaml
+++ b/apps/overlay/control-cluster/hr-failed.yaml
@@ -5,6 +5,8 @@ kind: HelmRepository
 metadata:
   name: komodorio
   namespace: test
+  annotations:
+    kagentFix: "2025-09-16T21:55:53Z"
 spec:
   interval: 1h0m0s
   url: https://helm-charts.komodor.io
@@ -14,6 +16,8 @@ kind: HelmRelease
 metadata:
   name: komoplane-15
   namespace: test
+  annotations:
+    kagentFix: "2025-09-16T21:55:53Z"
 spec:
   interval: 5m
   chart:
@@ -23,5 +27,5 @@ spec:
         kind: HelmRepository
         name: komodorio
   values:
-    replicaCount: 1oo
+    replicaCount: 1
 ---


### PR DESCRIPTION
RCA:
The HelmRelease apps/overlay/control-cluster/hr-failed.yaml contained an invalid string value for replicaCount: "1oo". During Helm install, Kubernetes failed to create the Deployment because Deployment.spec.replicas expects an integer (int32) and the string caused a JSON unmarshal error.

Remediation:
- Replace replicaCount: 1oo with replicaCount: 1 (integer)
- Annotate both HelmRepository and HelmRelease resources with kagentFix=2025-09-16T21:55:53Z so the change is traceable.

Actions performed by kagent ai agent:
- Created branch kagent-fix/komoplane-replicacount-20250916t215553
- Updated apps/overlay/control-cluster/hr-failed.yaml to fix replicaCount and added annotations
- Opened this pull request

Verification steps:
- Flux should reconcile the repository and apply the fixed HelmRelease. Verify HelmRelease/test/komoplane-15 status becomes ready and the underlying Deployment is created with replicas: 1.
- Check events in namespace test for successful Helm install.

Signed-off-by: kagent ai agent
