### PR TITLE
fix(helmrelease): set replicaCount as integer for komoplane-20 and annotate fix by kagent

### DIFF
--- a/apps/overlay/control-cluster/hr-failed.yaml
+++ b/apps/overlay/control-cluster/hr-failed.yaml
@@ -14,6 +14,8 @@ kind: HelmRelease
 metadata:
   name: komoplane-20
   namespace: test
+  annotations:
+    kagentFix: "2025-09-16T22:14:57Z"
 spec:
   interval: 5m
   chart:
@@ -23,5 +25,5 @@ spec:
         kind: HelmRepository
         name: komodorio
   values:
-    replicaCount: o1
+    replicaCount: 1
 ---


### PR DESCRIPTION
RCA:
The HelmRelease test/komoplane-20 failed to install because replicaCount was specified as a string value `o1` in the HelmRelease values. This resulted in Helm rendering Deployment.spec.replicas as a string which Kubernetes API rejects (expects integer int32), causing the install to fail with: "json: cannot unmarshal string into Go struct field DeploymentSpec.spec.replicas of type int32".

Remediation:
- Corrected apps/overlay/control-cluster/hr-failed.yaml to set `replicaCount: 1` (integer) instead of `o1`.
- Added annotation `kagentFix=2025-09-16T22:14:57Z` to the HelmRelease metadata to mark the automated remediation.

Implementation details:
- Created branch `fix/komoplane-replicacount-20250916` and updated the file `apps/overlay/control-cluster/hr-failed.yaml`.
- This change fixes the input to the Helm chart and allows Helm/Flux to install the release.

Action by: kagent ai agent