### PR TITLE
fix(komoplane): correct replicaCount type for test/komoplane-21 (kagent fix)

### DIFF
--- a/apps/overlay/d1-blue/mcp/flux-mcp-server/komoplane-override.yaml
+++ b/apps/overlay/d1-blue/mcp/flux-mcp-server/komoplane-override.yaml
@@ -1,0 +1,10 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: komoplane-21
+  namespace: test
+  annotations:
+    kagentFix: "2025-09-17T01:14:33Z"
+spec:
+  values:
+    replicaCount: 1

--- a/apps/overlay/d1-blue/mcp/flux-mcp-server/patches/komoplane-fix.yaml
+++ b/apps/overlay/d1-blue/mcp/flux-mcp-server/patches/komoplane-fix.yaml
@@ -1,0 +1,17 @@
+apiVersion: kpatch.kustomize.config.k8s.io/v1
+kind: Patch
+metadata:
+  name: komoplane-replicacount-fix
+patch: |
+  - op: replace
+    path: /spec/values/replicaCount
+    value: 1
+  - op: add
+    path: /metadata/annotations/kagentFix
+    value: "2025-09-17T01:14:33Z"
+target:
+  group: helm.toolkit.fluxcd.io
+  version: v2
+  kind: HelmRelease
+  name: komoplane-21
+  namespace: test


### PR DESCRIPTION
RCA:
- The HelmRelease test/komoplane-21 failed installation because spec.values.replicaCount
  was a string value "o1" (lowercase letter o) instead of an integer.
- Helm rendered a Deployment with spec.replicas set as a string which Kubernetes
  rejects (Deployment.spec.replicas is int32) causing install failure.

Remediation performed by kagent AI agent:
1. Added a patch file to repo (apps/overlay/d1-blue/mcp/flux-mcp-server/patches/komoplane-fix.yaml)
   describing the intended fix and annotated with kagentFix timestamp.
2. Added a HelmRelease override (apps/overlay/d1-blue/mcp/flux-mcp-server/komoplane-override.yaml)
   which sets spec.values.replicaCount to integer 1 and adds annotation kagentFix=<timestamp>.
   This ensures the invalid string value is corrected and the HelmRelease can be installed.

Notes and follow-ups:
- Root cause: typographical error converting zero to letter 'o' or mis-typed value in a generator.
  Search for sources of this value (automation tools or templates that create HelmReleases) to
  prevent regression.
- After this PR is merged, Flux/ResourceSet should reconcile and the corrected HelmRelease
  will be applied. If reconciliation still fails, the agent will attempt to delete and recreate
  the resource.

Opened-by: kagent ai agent
